### PR TITLE
OAM/RIOT/Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+pcap/
+log/
+tags

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,48 @@
-all:
+include config.inc
+
+ifneq ($(STACKLINE_RIOT),)
+STACKLINE_DEP+=riot
+STACKLINE_DEPCLEAN+=riot_clean
+endif
+
+ifneq ($(STACKLINE_CONTIKI),)
+STACKLINE_DEP+=contiki
+STACKLINE_DEPCLEAN+=contiki_clean
+endif
+
+ifneq ($(AIRLINE_NS3),)
+AIRLINE_DEP+=ns3
+AIRLINE_DEPCLEAN+=ns3_clean
+endif
+
+
+all: $(AIRLINE_DEP) whitefield $(STACKLINE_DEP)
+
+whitefield:
 	make -f src/commline/Makefile.commline all
 	make -f src/utils/Makefile.utils all
 	make -f src/airline/Makefile.airline all
 
+riot:
+	make -C $(STACKLINE_RIOT)/tests/whitefield
+
+riot_clean:
+	make -C $(STACKLINE_RIOT)/tests/whitefield clean
+
+contiki:
+	make -C $(STACKLINE_CONTIKI)/examples/ipv6/rpl-udp TARGET=whitefield
+
+contiki_clean:
+	make -C $(STACKLINE_CONTIKI)/examples/ipv6/rpl-udp TARGET=whitefield clean
+
+ns3:
+	make -C $(AIRLINE_NS3)
+
+ns3_clean:
+	make -C $(AIRLINE_NS3) clean
+
 clean:
-	@make -f src/airline/Makefile.airline clean
-	@rm -rf log pcap
+	@rm -rf bin log pcap
+
+allclean: $(STACKLINE_DEPCLEAN)
+	make clean

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Tested on: Ubuntu >= 16.04 (xenial), Debian GNU/Linux 8.7 (jessie)
 Disk Space: ~1.5GB
 ```
 sudo apt-get update
-sudo apt-get install gcc g++ make git graphviz
+sudo apt-get install gcc g++ make git graphviz build-essential libc6-dev-i386
 ```
 **Build Instructions**:
 

--- a/config.inc
+++ b/config.inc
@@ -1,5 +1,8 @@
-AIRLINK=NS3
-NS3PATH=thirdparty/ns-3-dev-git/build
+AIRLINE=NS3
+AIRLINE_NS3=thirdparty/ns-3-dev-git
+
+STACKLINE_CONTIKI=thirdparty/contiki
+STACKLINE_RIOT=thirdparty/RIOT
 
 REL=debug
 BINDIR=bin

--- a/invoke_whitefield.sh
+++ b/invoke_whitefield.sh
@@ -3,7 +3,7 @@
 [[ ! -f "config.inc" ]] && echo "Need to start whitefield from base folder!!" && exit 1
 . config.inc
 
-export LD_LIBRARY_PATH=$NS3PATH:$BINDIR
+export LD_LIBRARY_PATH=$AIRLINE_NS3/build:$BINDIR
 export FORKER=$BINDIR/wf_forker
 export LOGPATH=log
 export MONITOR_PORT=$MONITOR_PORT

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,9 +2,9 @@
 
 . config.inc
 
-if [ "$AIRLINK" == "NS3" ]; then #Build NS3
-	cd `dirname $NS3PATH`
-	./waf configure && make
+if [ "$AIRLINE_NS3" != "" ]; then #Build NS3
+	cd $AIRLINE_NS3
+	./waf configure
 	if [ $? -ne 0 ]; then
 		echo "********* NS3 Compilation failed *********"
 		exit 1
@@ -18,13 +18,4 @@ if [ $? -ne 0 ]; then
 	echo "********* Whitefield Compilation failed *********"
 	exit 1
 fi
-
-#Build Contiki examples
-cd thirdparty/contiki
-make -C examples/ipv6/rpl-udp TARGET=whitefield
-if [ $? -ne 0 ]; then
-	echo "********* Contiki Compilation failed *********"
-	exit 1
-fi
-cd -
 

--- a/src/airline/Makefile.airline
+++ b/src/airline/Makefile.airline
@@ -1,23 +1,24 @@
 include config.inc
 
+ifneq ($(AIRLINE_NS3),)
+AIRLINE=NS3
+CFLAGS+=-I$(AIRLINE_NS3)/build
+LIBS+=-L$(AIRLINE_NS3)/build -lns3-dev-core-$(REL) -lns3-dev-lr-wpan-$(REL) -lns3-dev-network-$(REL) -lns3-dev-spectrum-$(REL) -lns3-dev-mobility-$(REL) -lns3-dev-propagation-$(REL) -lns3-dev-stats-$(REL) -lns3-dev-antenna-$(REL)
+endif
+
 SRC=src/airline
 CL_SRC=src
-LIBS=-lpthread -L$(BINDIR) -lwf_commline
-CFLAGS=-std=c++11 -Wall -I$(CL_SRC) -I$(SRC)
+LIBS+=-lpthread -L$(BINDIR) -lwf_commline
+CFLAGS+=-std=c++11 -Wall -I$(CL_SRC) -I$(SRC)
 
 TARGET=$(BINDIR)/whitefield
 # Should be equivalent to your list of C files, if you don't build selectively
 SRCS=$(wildcard $(SRC)/*.cc)
-SRCS+=$(wildcard $(SRC)/$(AIRLINK)/*.cc)
+SRCS+=$(wildcard $(SRC)/$(AIRLINE)/*.cc)
 OBJS=$(addprefix $(BINDIR)/,$(SRCS:.cc=.o))
 #$(info $(OBJS))
-CFLAGS+=-I$(SRC)/$(AIRLINK)
+CFLAGS+=-I$(SRC)/$(AIRLINE)
 GLOBAL_HDR=$(SRC)/common.h $(SRC)/Config.h
-
-ifeq ($(AIRLINK),NS3)
-CFLAGS+=-I$(NS3PATH)
-LIBS+=-L$(NS3PATH) -lns3-dev-core-$(REL) -lns3-dev-lr-wpan-$(REL) -lns3-dev-network-$(REL) -lns3-dev-spectrum-$(REL) -lns3-dev-mobility-$(REL) -lns3-dev-propagation-$(REL) -lns3-dev-stats-$(REL) -lns3-dev-antenna-$(REL)
-endif
 
 ifeq ($(REL),debug)
 CFLAGS+=-g
@@ -35,7 +36,7 @@ $(BINDIR)/%.o: %.cc $(GLOBAL_HDR)
 	g++ -c -o $@ $< $(CFLAGS) $(LIBS)
 
 $(BINDIR)/$(SRC):
-	@mkdir -p $(BINDIR)/$(SRC)/$(AIRLINK)
+	@mkdir -p $(BINDIR)/$(SRC)/$(AIRLINE)
 
 clean:
 	@rm -rf $(BINDIR)

--- a/src/airline/NS3/AirlineManager.cc
+++ b/src/airline/NS3/AirlineManager.cc
@@ -227,7 +227,7 @@ void AirlineManager::msgReader(void)
 {
 	DEFINE_MBUF(mbuf);
 	while(1) {
-		cl_recvfrom_q(MTYPE(AIRLINE,CL_MGR_ID), mbuf, sizeof(mbuf_buf));
+		cl_recvfrom_q(MTYPE(AIRLINE,CL_MGR_ID), mbuf, sizeof(mbuf_buf), CL_FLAG_NOWAIT);
 		if(mbuf->len) {
 			msgrecvCallback(mbuf);
 			usleep(1);

--- a/src/commline/cl_msgq.c
+++ b/src/commline/cl_msgq.c
@@ -74,12 +74,12 @@ void msgq_cleanup(void)
 	INFO("msgq deleted\n");
 }
 
-int msgq_recvfrom(const long mtype, msg_buf_t *mbuf, uint16_t len)
+int msgq_recvfrom(const long mtype, msg_buf_t *mbuf, uint16_t len, uint16_t flags)
 {
 	int ret;
 
 	mbuf->len=0;
-	ret = msgrcv(gMsgQ_id, (void*)mbuf, len, mtype, IPC_NOWAIT);
+	ret = msgrcv(gMsgQ_id, (void*)mbuf, len, mtype, (flags & CL_FLAG_NOWAIT)?IPC_NOWAIT:0);
 	if(ret<0) {
 		if(ENOMSG == errno) return CL_SUCCESS;
 		return CL_FAILURE;

--- a/src/commline/cl_msgq.h
+++ b/src/commline/cl_msgq.h
@@ -23,7 +23,7 @@
 
 int msgq_init(const uint8_t flags);
 void msgq_cleanup(void);
-int msgq_recvfrom(const long mtype, msg_buf_t *mbuf, uint16_t len);
+int msgq_recvfrom(const long mtype, msg_buf_t *mbuf, uint16_t len, uint16_t flags);
 int msgq_sendto(const long mtype, msg_buf_t *mbuf, uint16_t len);
 
 #endif //_CL_MSGQ_H_

--- a/src/commline/cl_stackline_helpers.c
+++ b/src/commline/cl_stackline_helpers.c
@@ -25,20 +25,26 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <errno.h>
+#include <dlfcn.h>
 
 #include <commline.h>
 
-static uint8_t serial_id[] = {0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08};
+static uint8_t g_serial_id[] = {0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08};
 
 int cl_get_id2longaddr(const uint16_t id, uint8_t *addr, const int addrlen)
 {
-	if(addrlen != 8 || id == 0xffff) {
-		ERROR("Invalid addrlen:%d id:%x\n", addrlen, id);
+	if(addrlen != 8) {
+		ERROR("Invalid addrlen:%d\n", addrlen);
 		return CL_FAILURE;
 	}
+	if(id == 0xffff) {
+		memset(addr, 0, addrlen);
+		return CL_SUCCESS;
+	}
+
 	char *ptr=(char *)&id;
 
-	memcpy(addr, serial_id, 8);
+	memcpy(addr, g_serial_id, 8);
 	addr[6] = ptr[1];
 	addr[7] = ptr[0];
 	return CL_SUCCESS;
@@ -54,5 +60,72 @@ uint16_t cl_get_longaddr2id(const uint8_t *addr)
 	ptr[0] = addr[7];
 	ptr[1] = addr[6];
 	return nodeid;
+}
+
+#if 0
+#define	HANDLE_CMD(MBUF, CMD)	\
+	else if(!strncasecmp((char*)(MBUF)->buf, #CMD, sizeof(#CMD)-1))	\
+	{\
+		int aux_len=0;\
+		char *colon_ptr = strchr((char*)(MBUF)->buf, ':');\
+		if(colon_ptr) {\
+			*colon_ptr++=0;\
+			aux_len = strlen(colon_ptr);\
+			memmove((MBUF)->buf, colon_ptr, aux_len);\
+		}\
+		(MBUF)->buf[aux_len] = 0;\
+		(MBUF)->len = CMD(mbuf->src_id, (char*)(MBUF)->buf, COMMLINE_MAX_BUF);\
+	}
+#endif
+
+void *g_dl_lib_handle=NULL;
+typedef int (*cmd_handler_func_t)(uint16_t src_id, char*buf, int len);
+
+void sl_handle_cmd(msg_buf_t *mbuf)
+{
+	cmd_handler_func_t cmd_func;
+	int aux_len=0;
+	char *colon_ptr, cmd[256];
+
+	if(!g_dl_lib_handle) {
+		g_dl_lib_handle=dlopen(NULL, RTLD_LAZY);
+		if(!g_dl_lib_handle) {
+			ERROR("Could not load library!!\n");
+			return;
+		}
+	}
+	colon_ptr = strchr((char*)mbuf->buf, ':');
+	if(colon_ptr) {
+		*colon_ptr++=0;
+		aux_len = strlen(colon_ptr);
+		strncpy(cmd, (char*)mbuf->buf, sizeof(cmd)-1);
+		memmove(mbuf->buf, colon_ptr, aux_len);
+	} else {
+		strncpy(cmd, (char*)mbuf->buf, sizeof(cmd)-1);
+	}
+	cmd_func = (cmd_handler_func_t)dlsym(g_dl_lib_handle, cmd);
+	if(!cmd_func) {
+		ERROR("Could not load cmd: <%s>\n", cmd);
+		return;
+	}
+	mbuf->buf[aux_len] = 0;
+	mbuf->len = cmd_func(mbuf->src_id, (char*)mbuf->buf, COMMLINE_MAX_BUF);
+#if 0
+	if(0) { } 
+	HANDLE_CMD(mbuf, cmd_rpl_stats)
+	HANDLE_CMD(mbuf, cmd_def_route)
+	HANDLE_CMD(mbuf, cmd_route_table)
+	HANDLE_CMD(mbuf, cmd_rtsize)
+	HANDLE_CMD(mbuf, cmd_node_osname)
+	HANDLE_CMD(mbuf, cmd_ipv6_stats)
+	HANDLE_CMD(mbuf, cmd_nd6_stats)
+	HANDLE_CMD(mbuf, cmd_icmp_stats)
+	HANDLE_CMD(mbuf, cmd_udp_stats)
+	HANDLE_CMD(mbuf, cmd_tcp_stats)
+	HANDLE_CMD(mbuf, cmd_config_info)
+	else {
+		mbuf->len = sprintf((char*)mbuf->buf, "SL_INVALID_CMD(%s)", mbuf->buf);
+	}   
+#endif
 }
 

--- a/src/commline/commline.c
+++ b/src/commline/commline.c
@@ -46,13 +46,13 @@ int cl_sendto_q(const long mtype, msg_buf_t *mbuf, uint16_t len)
 	return msgq_sendto(mtype, mbuf, len);
 }
 
-int cl_recvfrom_q(const long mtype, msg_buf_t *mbuf, uint16_t len)
+int cl_recvfrom_q(const long mtype, msg_buf_t *mbuf, uint16_t len, uint16_t flags)
 {
 	if(!mbuf || !len) {
 		ERROR("invalid parameters passed buf:%p, buflen:%d\n", mbuf, len);
 		return CL_FAILURE;
 	}
 	memset(mbuf, 0, sizeof(msg_buf_t));
-	return msgq_recvfrom(mtype, mbuf, len);
+	return msgq_recvfrom(mtype, mbuf, len, flags);
 }
 

--- a/src/commline/commline.h
+++ b/src/commline/commline.h
@@ -46,8 +46,10 @@ typedef struct _msg_buf_
 	uint8_t flags;
 	union {
 		struct {
-			uint8_t lqi;	//Link quality indicator 
-			uint8_t rssi;
+			//Note that you can have one or both or none of the indicators.
+			//Value is 0 if not present. NS3 provides LQI only. Castalia provides RSSI.
+			uint8_t lqi;	//Link Quality Indicator 
+			int8_t rssi;	//Rcvd Signal Strength Indicator
 		}sig;
 		struct {
 			uint8_t retries;
@@ -63,7 +65,8 @@ typedef struct _msg_buf_
 		msg_buf_t *MBUF = (msg_buf_t *)MBUF##_buf;\
 		memset(MBUF##_buf, 0, sizeof(MBUF##_buf));
 
-int cl_recvfrom_q(const long mtype, msg_buf_t *mbuf, uint16_t len);
+#define	CL_FLAG_NOWAIT	(1<<1)
+int cl_recvfrom_q(const long mtype, msg_buf_t *mbuf, uint16_t len, uint16_t flags);
 int cl_sendto_q(const long mtype, msg_buf_t *mbuf, uint16_t len);
 
 enum {

--- a/src/stackline/sl_command.c
+++ b/src/stackline/sl_command.c
@@ -20,28 +20,5 @@
 
 #define	_SL_COMMAND_C_
 
-// This file is included from thirdparty stackline OS such as Contiki (see contiki/platform/whitefiled/command.c)
-// It sort of provides virtual abstract interfaces for different commands i.e. it mandates the stackline OS platform 
-// to implement these commands. This is essential to have a common OAM interfaces across different stacklines.
-
 #include "commline/commline.h"
-
-void sl_handle_cmd(msg_buf_t *mbuf)
-{
-	if(0) { } 
-	HANDLE_CMD(mbuf, cmd_rpl_stats)
-	HANDLE_CMD(mbuf, cmd_def_route)
-	HANDLE_CMD(mbuf, cmd_route_table)
-	HANDLE_CMD(mbuf, cmd_rtsize)
-	HANDLE_CMD(mbuf, cmd_node_osname)
-	HANDLE_CMD(mbuf, cmd_ipv6_stats)
-	HANDLE_CMD(mbuf, cmd_nd6_stats)
-	HANDLE_CMD(mbuf, cmd_icmp_stats)
-	HANDLE_CMD(mbuf, cmd_udp_stats)
-	HANDLE_CMD(mbuf, cmd_tcp_stats)
-	HANDLE_CMD(mbuf, cmd_config_info)
-	else {
-		mbuf->len = sprintf((char*)mbuf->buf, "SL_INVALID_CMD(%s)", mbuf->buf);
-	}   
-}
 

--- a/src/utils/forker.c
+++ b/src/utils/forker.c
@@ -94,13 +94,12 @@ void wait_on_q(void)
 
 	while(1)
 	{
-		if(CL_SUCCESS != cl_recvfrom_q(MTYPE(FORKER,CL_MGR_ID), mbuf, sizeof(buf))) {
+		if(CL_SUCCESS != cl_recvfrom_q(MTYPE(FORKER,CL_MGR_ID), mbuf, sizeof(buf), 0)) {
 			break;
 		}
 		if(mbuf->len) {
 			if((CL_SUCCESS != fork_n_exec(mbuf->src_id, (char *)mbuf->buf))) break;
 		}
-		usleep(1000);
 	}
 	killall_childprocess();
 	INFO("Quitting forker process\n");

--- a/src/utils/monitor.c
+++ b/src/utils/monitor.c
@@ -76,7 +76,7 @@ int fwd_cmd_on_commline(char *cmd, size_t cmdlen, char *rsp, size_t rsplen)
 	while(c++ < 100)
 	{
 		usleep(1000);
-		cl_recvfrom_q(MTYPE(MONITOR, CL_MGR_ID), mbuf, sizeof(mbuf_buf));
+		cl_recvfrom_q(MTYPE(MONITOR, CL_MGR_ID), mbuf, sizeof(mbuf_buf), CL_FLAG_NOWAIT);
 		if(mbuf->len > 0) {
 			memcpy_s(rsp, rsplen, mbuf->buf, mbuf->len);
 			rsp[mbuf->len++] = 0;

--- a/src/wf.cfg
+++ b/src/wf.cfg
@@ -18,5 +18,5 @@ macMaxRetry=3		#Max number of times the mac packet will be retried
 #---------[Stackline configuration]-------
 #nodeExec=thirdparty/contiki/examples/ipv6/rpl-udp/udp-client.whitefield $NODEID
 nodeExec[0]=thirdparty/contiki/examples/ipv6/rpl-udp/udp-server.whitefield $NODEID
+#nodeExec[1]=thirdparty/contiki/examples/ipv6/rpl-udp/udp-client.whitefield $NODEID
 nodeExec[1]="thirdparty/RIOT/tests/whitefield/bin/native/riot-whitefield.elf" -w $NODEID
-


### PR DESCRIPTION
OAM
- dynamic loading of OAM command handlers
- syncing common changes between contiki/riot

RIOT
- 6lo recv handled
- routing packets from wf to gnrc

Setup
- makefiles updated to ease making of stacklines, airlines, whitefield as a whole or alone.
- One time installation script eased.
- everything configurable from since config.inc