### PR TITLE
Packetqueue issues fixed. 

### DIFF
--- a/src/airline/NS3/Airline.cc
+++ b/src/airline/NS3/Airline.cc
@@ -100,6 +100,11 @@ namespace ns3
 			params.m_txOptions = TX_OPTION_ACK;
 		}
 		pktq.push(params);
+#if 0
+		if(GetNode()->GetId() == 1) {
+			INFO << GetNode()->GetId() << " packet q size:" << (int)pktq.size() << endl;
+		}
+#endif
 		Simulator::ScheduleNow (&LrWpanMac::McpsDataRequest, dev->GetMac(), params, p0);
 	};
 
@@ -185,6 +190,11 @@ namespace ns3
 			ERROR << "How can the pktq be empty on dataconfirm ind?? Investigate.\n";
 			return;
 		}
+#if 0
+		if(GetNode()->GetId() == 1) {
+			INFO << GetNode()->GetId() << " rcvd confirm ind\n";
+		}
+#endif
 		McpsDataRequestParams drparams = pktq.front();
 		if(drparams.m_txOptions == TX_OPTION_ACK) {
 			DEFINE_MBUF(mbuf);
@@ -220,7 +230,7 @@ namespace ns3
 			if(!dstr.empty()) {
 				m_macpktqlen = (uint8_t)stoi(dstr);
 			} else {
-				m_macpktqlen = 10;
+				m_macpktqlen = 20;
 			}
 		}
 	};

--- a/src/airline/NS3/AirlineManager.cc
+++ b/src/airline/NS3/AirlineManager.cc
@@ -199,7 +199,7 @@ int AirlineManager::startNetwork(wf::Config & cfg)
 		string ns3_capfile = CFG("NS3_captureFile");
 		if(!ns3_capfile.empty()) {
 			INFO << "NS3 Capture File:" << ns3_capfile << endl;
-			lrWpanHelper.EnablePcapAll (ns3_capfile, true);
+			lrWpanHelper.EnablePcapAll (ns3_capfile, false /*promiscuous*/);
 		}
 
 		AirlineHelper airlineApp;

--- a/src/commline/commline.h
+++ b/src/commline/commline.h
@@ -124,6 +124,18 @@ enum {
 		(MBUF)->len = CMD(mbuf->src_id, (char*)(MBUF)->buf, COMMLINE_MAX_BUF);\
 	}
 
+#define	PRINT_HEX(BUF, LEN, ...)	\
+{\
+	int i;\
+	printf(__VA_ARGS__);\
+	for(i=0;i<LEN;i++) {\
+		if(i && !(i%16)) printf("\n");\
+		else if(i && !(i%8)) printf("\t");\
+		printf("%02x ", (uint8_t)BUF[i]);\
+	}\
+	printf("\n");\
+}
+
 // Stackline Helpers
 #include "cl_stackline_helpers.h"
 

--- a/src/wf.cfg
+++ b/src/wf.cfg
@@ -1,6 +1,6 @@
 #key[start-end]=val ... Description, isMandatory?, supportsRange?, exampleValue
 
-numOfNodes=10
+numOfNodes=2
 
 #---------[Airline configuration]-------
 #randSeed=0xabcdef #If not set every time a random seed is used
@@ -16,7 +16,7 @@ macPktQlen=10		#Maximum number of packets that can be outstanding on mac layer
 macMaxRetry=3		#Max number of times the mac packet will be retried
 
 #---------[Stackline configuration]-------
-#nodeExec=thirdparty/contiki/examples/ipv6/rpl-udp/udp-client.whitefield $NODEID
-nodeExec="thirdparty/RIOT/tests/whitefield/bin/native/riot-whitefield.elf" -w $NODEID
+nodeExec=thirdparty/contiki/examples/ipv6/rpl-udp/udp-client.whitefield $NODEID
+#nodeExec="thirdparty/RIOT/tests/whitefield/bin/native/riot-whitefield.elf" -w $NODEID
 nodeExec[0]=thirdparty/contiki/examples/ipv6/rpl-udp/udp-server.whitefield $NODEID
-nodeExec[1]="thirdparty/RIOT/tests/whitefield/bin/native/riot-whitefield.elf" -w $NODEID
+#nodeExec[1]="thirdparty/RIOT/tests/whitefield/bin/native/riot-whitefield.elf" -w $NODEID


### PR DESCRIPTION
- Increased packet queue at MAC layer in NS3. RIOT has this behaviour where it sends lot of Neighbor solicitations and router advertisement in a single stretch (looks like it tight loop). This causes lot of problems, especially MAC queues getting full, increased packet failures etc. I will go into details of why RIOT does this but for now I m increasing the queue limit from 10 to 30 ... This means increased memory usage.
- For pcap, i was using promiscuous mode. Unsetted that. Still needs refinements towards how pcap should show up. Currently there is always an icmpv6 checksum error that shows up in the wireshark. But the problem is related to mismatch of stackline and airline behaviours. NS3 airline only supports short addressing scheme and stacklines only use long addressing. Because of this the address decompression results in different values and this has to be fixed properly.