### PR TITLE
added event based handling for openthread

### DIFF
--- a/src/commline/cl_usock.c
+++ b/src/commline/cl_usock.c
@@ -89,6 +89,11 @@ int usock_recvfrom(const long my_mtype, msg_buf_t *mbuf, uint16_t len, uint16_t 
 	int ret;
     int line=GET_LINE(my_mtype);
 
+    if(!IN_RANGE(line, 1, MAX_CL_LINE)) {
+        ERROR("my_mtype:%08lx not in range!\n", my_mtype);
+        return CL_FAILURE;
+    }
+
 	mbuf->len=0;
     ret = recvfrom(g_usock_fd[line], (void*)mbuf, len, (flags & CL_FLAG_NOWAIT)?MSG_DONTWAIT:0, NULL, 0);
 	if(ret>0 && ret+4<sizeof(msg_buf_t)) //Rahul: +4 is added for bins compiled with -m32. sizeof(long) issue.
@@ -96,9 +101,6 @@ int usock_recvfrom(const long my_mtype, msg_buf_t *mbuf, uint16_t len, uint16_t 
 		ERROR("problem ... recvfrom len(%d) not enough sizeof:%zu\n", ret, sizeof(msg_buf_t));
 		return CL_FAILURE;
 	}
-    if(ret > 0) {
-        INFO("usock recvfrom ret:%d\n", ret);
-    }
 	return ret;
 }
 
@@ -119,3 +121,17 @@ int usock_sendto(const long mtype, msg_buf_t *mbuf, uint16_t len)
 	return CL_SUCCESS;
 }
 
+int usock_get_descriptor(const long mtype)
+{
+    int line=GET_LINE(mtype);
+    if(!IN_RANGE(line, 1, MAX_CL_LINE)) {
+        ERROR("my_mtype:%08lx not in range!\n", mtype);
+        return CL_FAILURE;
+    }
+    if(g_usock_fd[line] <= 0) {
+        ERROR("mtype:%08lx line:%d no fd here\n", mtype, line);
+        return CL_FAILURE;
+    }
+
+    return g_usock_fd[line];
+}

--- a/src/commline/cl_usock.h
+++ b/src/commline/cl_usock.h
@@ -25,10 +25,12 @@ int usock_init(const long my_mtype, const uint8_t flags);
 void usock_cleanup(void);
 int usock_recvfrom(const long mtype, msg_buf_t *mbuf, uint16_t len, uint16_t flags);
 int usock_sendto(const long mtype, msg_buf_t *mbuf, uint16_t len);
+int usock_get_descriptor(const long mtype);
 
-#define CL_INIT     usock_init
-#define CL_CLEANUP  usock_cleanup
-#define CL_RECVFROM usock_recvfrom
-#define CL_SENDTO   usock_sendto
+#define CL_INIT             usock_init
+#define CL_CLEANUP          usock_cleanup
+#define CL_RECVFROM         usock_recvfrom
+#define CL_SENDTO           usock_sendto
+#define CL_GET_DESCRIPTOR   usock_get_descriptor
 
 #endif //_CL_MSGQ_H_

--- a/src/commline/commline.c
+++ b/src/commline/commline.c
@@ -70,3 +70,13 @@ int cl_recvfrom_q(const long mtype, msg_buf_t *mbuf, uint16_t len, uint16_t flag
 	return CL_RECVFROM(mtype, mbuf, len, flags);
 }
 
+int cl_get_descriptor(const long mtype)
+{
+#ifdef  USE_UNIX_SOCKETS
+    return CL_GET_DESCRIPTOR(mtype);
+#else
+    ERROR("Get descriptor not supported for used IPC\n");
+    return CL_FAILURE;
+#endif
+}
+

--- a/src/commline/commline.h
+++ b/src/commline/commline.h
@@ -87,6 +87,7 @@ typedef struct _msg_buf_
 #define	CL_FLAG_NOWAIT	(1<<1)
 int cl_recvfrom_q(const long mtype, msg_buf_t *mbuf, uint16_t len, uint16_t flags);
 int cl_sendto_q(const long mtype, msg_buf_t *mbuf, uint16_t len);
+int cl_get_descriptor(const long mtype);
 
 enum {
 	STACKLINE=1,

--- a/src/stackline/wf_openthread/wfot_pty_handler.c
+++ b/src/stackline/wf_openthread/wfot_pty_handler.c
@@ -100,10 +100,15 @@ int uds_open(void)
 
 extern "C" void __wrap_platformUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aErrorFdSet, int *aMaxFd)
 {
+    int commline_fd;
     extern void __real_platformUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aErrorFdSet, int *aMaxFd);
     ADD_TO_FDSET(g_uds_childfd);
     if(g_uds_childfd < 0) {
         ADD_TO_FDSET(g_uds_fd);
+    }
+    commline_fd = cl_get_descriptor(MTYPE(STACKLINE, NODE_ID-1));
+    if(commline_fd > 0) {
+        ADD_TO_FDSET(commline_fd);
     }
     return __real_platformUartUpdateFdSet(aReadFdSet, aWriteFdSet, aErrorFdSet, aMaxFd);
 }

--- a/src/stackline/wf_openthread/wfot_radio_wrapper.c
+++ b/src/stackline/wf_openthread/wfot_radio_wrapper.c
@@ -219,7 +219,6 @@ void wfHandleCommlineEvent(void)
 
     ret = cl_recvfrom_q(MTYPE(STACKLINE, NODE_ID-1), mbuf, sizeof(mbuf_buf), CL_FLAG_NOWAIT);
     if(0 == mbuf->len) {
-        INFO("No pkt on commline\n");
         return;
     }
     INFO("rcvd pkt len:%d on commline ret:%d\n", mbuf->len, ret);


### PR DESCRIPTION
Get a unix socket descriptor from commline and add it to openthread select() fdset so as to enable event based reading of commline messages.