### PR TITLE
node promiscuous mode added

### DIFF
--- a/config/wf-contiki-ng.cfg
+++ b/config/wf-contiki-ng.cfg
@@ -9,6 +9,7 @@ fieldY=400  #field space in y direction
 topologyType=grid	#grid, randrect (ns3 RandomRectanglePositionAllocator), 
 gridWidth=5  #Grid topology width if the topologyType=grid
 #nodePosition[1]=10,20,0 #Change the node position to the given vector
+#nodePromiscuous[2]=1 #Sets promiscuous mode for node
 
 panID=0xabcd
 NS3_captureFile=pcap/pkt

--- a/config/wf.cfg
+++ b/config/wf.cfg
@@ -9,6 +9,7 @@ fieldY=400  #field space in y direction
 topologyType=grid	#grid, randrect (ns3 RandomRectanglePositionAllocator), 
 gridWidth=5  #Grid topology width if the topologyType=grid
 #nodePosition[1]=10,20,0 #Change the node position to the given vector
+#nodePromiscuous[2]=1 #Sets promiscuous mode for node
 
 panID=0xabcd
 NS3_captureFile=pcap/pkt

--- a/docs/wf_config_help.md
+++ b/docs/wf_config_help.md
@@ -13,6 +13,7 @@ stackline.
 | |grid | Grid topology where nodes are separated by distance specified by fieldX * fieldY and the width of the grid is specified by gridWidth|
 |gridWidth| Uint range | Width of the grid. Only applicable when topologyType=grid |
 |nodePosition[*]|10,20,0|Manually position the node at the given location specified by x,y,z coordinates|
+|nodePromiscuous[*]|1|Set promiscuous mode for the node. Node will receive not only broadcast or unicast packets destined to it but also other packets not destined to it but the node is in receive range.|
 |panID|Ushort range| PAN identifier to be used in LOWPAN |
 |macPktQlen|<100|Maximum number of packets that can be buffered/queued at MAC layer|
 |macMaxRetry| <20 | Maximum number of times the mac packet will be retried |

--- a/src/airline/Config.cc
+++ b/src/airline/Config.cc
@@ -208,6 +208,15 @@ int Config::setNodePosition(const string position, int beg, int end)
 	return SUCCESS;
 }
 
+int Config::setNodePromis(const string pmode, int beg, int end)
+{
+	int i;
+	for(i=beg;i<=end;i++) {
+		nodeArray[i].setPromisMode(stoi(pmode));
+	}
+	return SUCCESS;
+}
+
 int Config::setConfigurationFromFile(const char *fname)
 {
 	int beg_range, end_range;
@@ -248,6 +257,8 @@ int Config::setConfigurationFromFile(const char *fname)
 					setNodeSetCapFile(value, beg_range, end_range);
 				} else if(key == "nodePosition") {
 					setNodePosition(value, beg_range, end_range);
+				} else if(key == "nodePromiscuous") {
+					setNodePromis(value, beg_range, end_range);
 				} else {
 					set(key, value);
 				}

--- a/src/airline/Config.h
+++ b/src/airline/Config.h
@@ -34,6 +34,7 @@ private:
     int setNodeSetExec(const string exec, int beg, int end);
     int setNodeSetCapFile(const string path, int beg, int end);
     int setNodePosition(const string position, int beg, int end);
+    int setNodePromis(const string pmode, int beg, int end);
 
     void   clearNodeArray(void);
     string getKeyRange(const string &keystr, int &beg_range, int &end_range);

--- a/src/airline/NS3/AirlineManager.h
+++ b/src/airline/NS3/AirlineManager.h
@@ -42,7 +42,7 @@ private:
     int     cmd_802154_set_ext_addr(uint16_t id, char *buf, int buflen);
     int     cmd_802154_set_panid(uint16_t id, char *buf, int buflen);
     void    setPositionAllocator(NodeContainer &nodes);
-    void    setNodeSpecificPosition(NodeContainer &nodes);
+    void    setNodeSpecificParam(NodeContainer &nodes);
     void    setMacHeaderAdd(NodeContainer &nodes);
     void    msgReader(void);
     void    ScheduleCommlineRX(void);

--- a/src/airline/Nodeinfo.h
+++ b/src/airline/Nodeinfo.h
@@ -31,6 +31,7 @@ private:
     string  capFile;
     double  X, Y, Z;
     uint8_t pos_set;
+    uint8_t promis_mode;
 
 public:
     string getNodeExecutable(void)
@@ -44,6 +45,14 @@ public:
     void setNodeCaptureFile(const string path)
     {
         capFile = path;
+    };
+    void setPromisMode(int val)
+    {
+        promis_mode = !!val;
+    };
+    int getPromisMode(void)
+    {
+        return promis_mode;
     };
     void setNodePosition(const double x_pos, const double y_pos, const double z_pos)
     {
@@ -64,6 +73,7 @@ public:
     Nodeinfo()
     {
         pos_set = 0;
+        promis_mode = 0;
     };
 };
 } //namespace wf


### PR DESCRIPTION
This feature adds a mechanism to set promiscuous mode individually on a node (or range of nodes).

wf.cfg can now contain:
```
nodePromiscuous[2]=1 #Sets promiscuous mode for node 2
nodePromiscuous[4-8]=1 #Sets promiscuous mode for nodes 4,5,6,7,8
```

This can allow a node to operate in sniffer mode for all the packets in its receive range.