### PR TITLE
plot-network graph coloring

### DIFF
--- a/scripts/get_node_attr.sh
+++ b/scripts/get_node_attr.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Not to be called directly. Called through network_graph.sh
+
+# This scripts returns the node attributes to be used by plot_network_graph.
+# This may be used for other purpose in the future, hence the output in json
+# format.
+
+# Currently this scripts checks the node executable and returns the node-color.
+
+DIR=`dirname $0`
+[[ "$1" == "" ]] && echo "Usage: $0 <nodeid>" && exit 1
+
+# https://graphviz.org/doc/info/colors.html
+get_node_color()
+{
+    nexec=`$DIR/wfshell cmd_node_exec $1`
+    bin=`basename "${nexec/ */}"`
+    color="${DEFCOLOR-greenyellow}"
+    if [[ $bin =~ .*udp-server.* ]]; then
+        color="${BRCOLOR-darkgreen}"
+    fi
+
+    echo "{ \"color\": \"$color\" }"
+}

--- a/scripts/internal/cmd_list.txt
+++ b/scripts/internal/cmd_list.txt
@@ -14,6 +14,7 @@ sl cmd_start_udp
 al cmd_mac_stats
 al cmd_set_node_position
 al cmd_node_position
+al cmd_node_exec
 fw stop_whitefield
 fw plot_network_graph
 fw path_upstream

--- a/scripts/network_graph.sh
+++ b/scripts/network_graph.sh
@@ -2,6 +2,7 @@
 
 DIR=`dirname $0`
 . $DIR/helpers.sh
+. $DIR/get_node_attr.sh
 TMP="/tmp/wf_graphviz_$$"
 POSF="/tmp/wf_node_pos_$$"
 
@@ -22,6 +23,10 @@ tree_graph() {
 			#echo "Node $id, parent $prnt_id"
 			echo "$id -> $prnt_id;" >> $TMP
 		fi
+	done
+	for((i=0;i<${#nodelist[@]};i++)); do
+        color=`get_node_color $i | jq -r .color`
+		echo "$i [ fillcolor=$color style=filled]" >> $TMP
 	done
 	echo "}" >> $TMP
 	dot -Tpng $TMP > $1
@@ -52,10 +57,11 @@ position_graph() {
 	readarray nodepos < $POSF
     [[ "$scale" == "" ]] && scale=1
 	for((i=0;i<${#nodepos[@]};i++)); do
+        color=`get_node_color $i | jq -r .color`
 		IFS=' ' read -r -a arr <<< "${nodepos[$i]}"
         xpos=`echo "${arr[3]}*$scale" | bc -q`
         ypos=`echo "${arr[4]}*$scale" | bc -q`
-		echo "${arr[1]} [ pos=\"${xpos},${ypos}!\"]" >> $TMP
+		echo "${arr[1]} [ pos=\"${xpos},${ypos}!\" fillcolor=$color style=filled]" >> $TMP
 	done
 
 	echo "}" >> $TMP

--- a/src/airline/NS3/AirlineManager.cc
+++ b/src/airline/NS3/AirlineManager.cc
@@ -26,6 +26,28 @@
 #include "mac_stats.h"
 #include "Nodeinfo.h"
 
+int getNodeConfigVal(int id, char *key, char *val, int vallen)
+{
+	wf::Nodeinfo *ni=NULL;
+    ni=WF_config.get_node_info(id);
+    if (!ni) {
+        snprintf(val, vallen, "cudnot get nodeinfo id=%d", id);
+        ERROR << "Unable to get node config\n";
+        return 0;
+    }
+    if (!strcmp(key, "nodeexec")) {
+        return snprintf(val, vallen, "%s", (char *)ni->getNodeExecutable().c_str());
+    }
+    snprintf(val, vallen, "unknown key [%s]", key);
+    ERROR << "Unknown key " << key << "\n";
+    return 0;
+}
+
+int AirlineManager::cmd_node_exec(uint16_t id, char *buf, int buflen)
+{
+    return getNodeConfigVal(id, (char *)"nodeexec", buf, buflen);
+}
+
 int AirlineManager::cmd_node_position(uint16_t id, char *buf, int buflen)
 {
 	int n=0;
@@ -176,6 +198,7 @@ void AirlineManager::msgrecvCallback(msg_buf_t *mbuf)
 
 	if(mbuf->flags & MBUF_IS_CMD) {
         if(0) {}
+		HANDLE_CMD(mbuf, cmd_node_exec)
 		HANDLE_CMD(mbuf, cmd_node_position)
 		HANDLE_CMD(mbuf, cmd_set_node_position)
 		HANDLE_CMD(mbuf, cmd_802154_set_short_addr)

--- a/src/airline/NS3/AirlineManager.h
+++ b/src/airline/NS3/AirlineManager.h
@@ -36,6 +36,7 @@ private:
     void    msgrecvCallback(msg_buf_t *mbuf);
     int     startNetwork(wf::Config &cfg);
     void    nodePos(NodeContainer const &nodes, uint16_t id, double &x, double &y, double &z);
+    int     cmd_node_exec(uint16_t id, char *buf, int buflen);
     int     cmd_node_position(uint16_t id, char *buf, int buflen);
     int     cmd_set_node_position(uint16_t id, char *buf, int buflen);
     int     cmd_802154_set_short_addr(uint16_t id, char *buf, int buflen);


### PR DESCRIPTION
fix for #99 

Support for plotted graph nodes coloring.

Usage:

## Plot using default colors 
Lightgreen is used for udp-client and dark green for udp-server.
```
./scripts/wfshell plot_network_graph t.png p.png 
```

## To change colors
```
BRCOLOR=blue DEFCOLOR=red ./scripts/wfshell plot_network_graph t.png p.png
```
Color plot can be obtained [here](https://graphviz.org/doc/info/colors.html).

## Advanced
Each node can be colored differently depending on its attributes. An external script `scripts/get_node_attr.sh` controls the colors to be used and can be modified on per project basis.