### PR TITLE
synced RIOT's whitefield fork to upstream latest

### DIFF
--- a/regression/basic/two_mixed_nodes.cfg
+++ b/regression/basic/two_mixed_nodes.cfg
@@ -6,8 +6,9 @@ numOfNodes=2
 #randSeed=0xabcdef #If not set every time a random seed is used
 fieldX=40  #field space in x direction ... currently 2D model is supp only.
 fieldY=40  #field space in y direction
-topologyType=grid	#grid, randrect (ns3 RandomRectanglePositionAllocator), 
+topologyType=grid	#grid, randrect (ns3 RandomRectanglePositionAllocator),
 gridWidth=4  #Grid topology width if the topologyType=grid
+NS3_captureFile=pcap/pkt
 #nodePosition[1]=10,20,0 #Change the node position to the given vector
 
 panID=0xabcd

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,7 +2,7 @@
 
 CFG_INC=config.inc
 
-RIOT_EN=0
+RIOT_EN=1
 STACKLINE_RIOT=thirdparty/RIOT
 
 CTK_EN=1
@@ -22,7 +22,7 @@ REL=debug
 get_def_monitor_port()
 {
     let MONITOR_PORT=65536-`id -u`-6
-    [[ $MONITOR_PORT -lt 1024 ]] && 
+    [[ $MONITOR_PORT -lt 1024 ]] &&
         echo "MONITOR_PORT=$MONITOR_PORT is inappropriate!" &&
         exit 1
 }
@@ -119,9 +119,7 @@ create_config()
 chk_cmd_present()
 {
 	echo -en "checking [$1] ... "
-	dpkg -S $1 >/dev/null 2>&1
-	[[ $? -ne 0 ]] && sudo apt install -y $1
-	echo -en "done\n"
+	sudo apt install -y $1
 }
 
 chk_prerequisite()

--- a/src/commline/commline.h
+++ b/src/commline/commline.h
@@ -157,7 +157,7 @@ enum {
 #define INFO(...)              \
     PRN("INFO ", __VA_ARGS__); \
     fflush(NULL)
-#define WARN(...) PRN("WARN " __VA_ARGS__)
+#define WARN(...) PRN("WARN ", __VA_ARGS__)
 #endif //ERROR
 
 /* MAC DataConfirmation status */


### PR DESCRIPTION
Handles issue #118. A very old version of RIOT was been made use of in Whitefield. Synced to the latest. Handled all the modifications for the latest RIOT.

These changes make it possible to use Whitefield with RIOT+contiki on Ubuntu 20.04 with the latest GCC.

The next milestone in this context is to work out Whitefield's plug-and-play mode with RIOT.

Also fixed a bug in `WARN(...)` handling in commline.