### PR TITLE
focal64 support with vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,24 @@ make
 </details>
 
 <details>
-  <summary>Build Instructions (Vagrant Install)</summary>
+  <summary>Build Instructions (Vagrant Install with Ubuntu 18.04)</summary>
 
 ```
 git clone https://github.com/whitefield-framework/whitefield
 cd whitefield
 vagrant up	# <- step takes time
 vagrant ssh
+```
+</details>
+
+<details>
+  <summary>Build Instructions (Vagrant Install with Ubuntu 20.04)</summary>
+
+```
+git clone https://github.com/whitefield-framework/whitefield
+cd whitefield
+IMG=focal64 vagrant up	# <- step takes time
+IMG=focal64 vagrant ssh
 ```
 </details>
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,12 @@
 Vagrant.require_version ">= 2.0.0"
 
-VM_IMG = "ubuntu/bionic64"
-VM_NAME = "whitefield-dev"
+if ENV['IMG'] == "focal64" then
+  VM_IMG = "ubuntu/focal64"
+  VM_NAME = "whitefield-focal64"
+else
+  VM_IMG = "ubuntu/bionic64"
+  VM_NAME = "whitefield-dev"
+end
 
 system("
     if [ #{ARGV[0]} = 'up' ]; then


### PR DESCRIPTION
Allows using vagrant with Ubuntu 20.04

Usage:
```
IMG=focal64 vagrant up
IMG=focal64 vagrant ssh
```